### PR TITLE
zuul: use debian-packaging-bullseye

### DIFF
--- a/zuul.yaml
+++ b/zuul.yaml
@@ -1,3 +1,3 @@
 - project:
     templates:
-      - debian-packaging-template
+      - debian-packaging-bullseye


### PR DESCRIPTION
why: because debian-packaging-template use buster worker